### PR TITLE
Add isForced argument, which forces respawn even without node flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ flaggedRespawn(v8flags, process.argv, function (ready, child) {
 
 ## API
 
-### <u>flaggedRespawn(flags, argv, [ forcedFlags, ] callback) : Void</u>
+### <u>flaggedRespawn(flags, argv, [ forcedFlags, ] [ isForced , ] callback) : Void</u>
 
 Respawns the script itself when *argv* has special flag contained in *flags* and/or *forcedFlags* is not empty. Because members of *flags* and *forcedFlags* are passed to `node` command, each of them needs to be a node flag or a V8 flag.
+
+In addition, this function respawns also when *isForced* is specified and its value is true. 
 
 #### Forbid respawning
 
@@ -66,7 +68,8 @@ If `--no-respawning` flag is given in *argv*, this function does not respawned e
 |:--------------|:------:|:----------------------------------------------------|
 | *flags*       | Array  | An array of node flags and V8 flags which are available when present in *argv*. |
 | *argv*        | Array  | Command line arguments to respawn.   |
-| *forcedFlags* | Array or String  | An array of node flags or a string of a single flag and V8 flags for respawning forcely. |
+| *forcedFlags* | Array or String  | An array of node flags or a string of a single flag and V8 flags for respawning forcely. (Optional) |
+| *isForced*    | boolean | A flag to force respawn even if *forcedFlags* is empty or not specified. (Optional) |
 | *callback*    | function | A called function when not respawning or after respawned. |
 
 * **<u><i>callback</i>(ready, proc, argv) : Void</u>**

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const remover = require('./lib/remover');
 
 const FORBID_RESPAWNING_FLAG = '--no-respawning';
 
-module.exports = function (flags, argv, forcedFlags, execute) {
+module.exports = function (flags, argv, forcedFlags, isForced, execute) {
   if (!flags) {
     throw new Error('You must specify flags to respawn with.');
   }
@@ -15,6 +15,17 @@ module.exports = function (flags, argv, forcedFlags, execute) {
   if (typeof forcedFlags === 'function') {
     execute = forcedFlags;
     forcedFlags = [];
+    isForced = false;
+
+  } else if (typeof isForced === 'function') {
+    execute = isForced;
+
+    if (typeof forcedFlags === 'boolean') {
+      isForced = forcedFlags;
+      forcedFlags = [];
+    } else {
+      isForced = false;
+    }
   }
 
   if (typeof forcedFlags === 'string') {
@@ -41,6 +52,10 @@ module.exports = function (flags, argv, forcedFlags, execute) {
     reordered = reordered.slice(0, 1)
       .concat(forcedFlags)
       .concat(reordered.slice(1));
+    ready = false;
+  }
+
+  if (isForced) {
     ready = false;
   }
 

--- a/test/bin/force-and-forbid-respawning-1.js
+++ b/test/bin/force-and-forbid-respawning-1.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const flaggedRespawn = require('../../');
+const v8flags = require('v8flags');
+
+// get a list of all possible v8 flags for the running version of node
+v8flags(function(err, flags) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  var argv = process.argv.concat('--no-respawning');
+
+  flaggedRespawn(flags, argv, ['--trace-deprecation'], true, function (ready, child) {
+    if (ready) {
+      console.log('Running!');
+    } else {
+      console.log('Respawning!');
+    }
+  });
+});
+

--- a/test/bin/force-and-forbid-respawning-2.js
+++ b/test/bin/force-and-forbid-respawning-2.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const flaggedRespawn = require('../../');
+const v8flags = require('v8flags');
+
+// get a list of all possible v8 flags for the running version of node
+v8flags(function(err, flags) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  var argv = process.argv.concat('--no-respawning');
+
+  flaggedRespawn(flags, argv, true, function (ready, child) {
+    if (ready) {
+      console.log('Running!');
+    } else {
+      console.log('Respawning!');
+    }
+  });
+});
+

--- a/test/bin/force-respawning-isforced-0.js
+++ b/test/bin/force-respawning-isforced-0.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const flaggedRespawn = require('../../');
+const v8flags = require('v8flags');
+
+// get a list of all possible v8 flags for the running version of node
+v8flags(function(err, flags) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  flaggedRespawn(flags, process.argv, [], true, function (ready, child) {
+    if (ready) {
+      console.log('Running!');
+    } else {
+      console.log('Respawning!');
+    }
+  });
+});
+

--- a/test/bin/force-respawning-isforced-1.js
+++ b/test/bin/force-respawning-isforced-1.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const flaggedRespawn = require('../../');
+const v8flags = require('v8flags');
+
+// get a list of all possible v8 flags for the running version of node
+v8flags(function(err, flags) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  flaggedRespawn(flags, process.argv, [], false, function (ready, child) {
+    if (ready) {
+      console.log('Running!');
+    } else {
+      console.log('Respawning!');
+    }
+  });
+});
+

--- a/test/bin/force-respawning-isforced-2.js
+++ b/test/bin/force-respawning-isforced-2.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const flaggedRespawn = require('../../');
+const v8flags = require('v8flags');
+
+// get a list of all possible v8 flags for the running version of node
+v8flags(function(err, flags) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  flaggedRespawn(flags, process.argv, true, function (ready, child) {
+    if (ready) {
+      console.log('Running!');
+    } else {
+      console.log('Respawning!');
+    }
+  });
+});
+

--- a/test/bin/force-respawning-isforced-3.js
+++ b/test/bin/force-respawning-isforced-3.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const flaggedRespawn = require('../../');
+const v8flags = require('v8flags');
+
+// get a list of all possible v8 flags for the running version of node
+v8flags(function(err, flags) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  flaggedRespawn(flags, process.argv, false, function (ready, child) {
+    if (ready) {
+      console.log('Running!');
+    } else {
+      console.log('Respawning!');
+    }
+  });
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -255,6 +255,85 @@ describe('flaggedRespawn', function () {
         done();
       }
     });
+
+    it('should force respawning when isForced is true and forcedFlags is empty', function(done) {
+      var cmd = [
+        'node',
+        path.resolve(__dirname, 'bin/force-respawning-isforced-0.js'),
+      ].join(' ');;
+
+      exec(cmd, function cb(err, stdout, stderr) {
+        expect(err).to.equal(null);
+        expect(stderr).to.equal('');
+        expect(stdout).to.equal('Respawning!\nRunning!\n');
+        done();
+      });
+    });
+
+    it('should not force respawning when isForced is false and forcedFlags is empty', function(done) {
+      var cmd = [
+        'node',
+        path.resolve(__dirname, 'bin/force-respawning-isforced-1.js'),
+      ].join(' ');;
+
+      exec(cmd, function cb(err, stdout, stderr) {
+        expect(err).to.equal(null);
+        expect(stderr).to.equal('');
+        expect(stdout).to.equal('Running!\n');
+        done();
+      });
+    });
+
+    it('should force respawning when isForced is true and no forcedFlags', function(done) {
+      var cmd = [
+        'node',
+        path.resolve(__dirname, 'bin/force-respawning-isforced-2.js'),
+      ].join(' ');;
+
+      exec(cmd, function cb(err, stdout, stderr) {
+        expect(err).to.equal(null);
+        expect(stderr).to.equal('');
+        expect(stdout).to.equal('Respawning!\nRunning!\n');
+        done();
+      });
+    });
+
+    it('should not force respawning when isForced is false and no forcedFlags', function(done) {
+      var cmd = [
+        'node',
+        path.resolve(__dirname, 'bin/force-respawning-isforced-3.js'),
+      ].join(' ');;
+
+      exec(cmd, function cb(err, stdout, stderr) {
+        expect(err).to.equal(null);
+        expect(stderr).to.equal('');
+        expect(stdout).to.equal('Running!\n');
+        done();
+      });
+    });
+
+    it('should take priority to forbidding than forcing with isForced and forcedFlags', function(done) {
+      exec('node ./test/bin/force-and-forbid-respawning-1.js', cb);
+
+      function cb(err, stdout, stderr) {
+        expect(err).to.equal(null);
+        expect(stderr).to.equal('');
+        expect(stdout).to.equal('Running!\n');
+        done();
+      }
+    });
+
+    it('should take priority to forbidding than forcing with isForced and no forcedFlags', function(done) {
+      exec('node ./test/bin/force-and-forbid-respawning-2.js', cb);
+
+      function cb(err, stdout, stderr) {
+        expect(err).to.equal(null);
+        expect(stderr).to.equal('');
+        expect(stdout).to.equal('Running!\n');
+        done();
+      }
+    });
+
   });
 
   describe('cli args which are passed to app', function() {


### PR DESCRIPTION
This pr adds *isForced* argument to this module. *isForced* is to force respawn even if *forcedFlags* is empty or is not specified.

I will modify Liftoff to respawn itself when cwd or configPath is specified explicitly, in order to add `node_modules` in cwd to environment variable `NODE_PATH`. (`process.env.NODE_PATH` is not allowed to change in a program). 

By this, for example, gulp can load modules in `node_modules` in both gulpfile directory and cwd. (And this will solve the issues gulpjs/gulp#2126 and  js-cli/js-liftoff#55.)